### PR TITLE
fix: compatibility with previous proxy owner

### DIFF
--- a/src/verifier.cairo
+++ b/src/verifier.cairo
@@ -28,7 +28,7 @@ mod Verifier {
         blacklisted_point: LegacyMap::<felt252, bool>,
         _starknetid_contract: ContractAddress,
         _public_key: felt252,
-        admin: ContractAddress,
+        Proxy_admin: ContractAddress,
     }
 
     #[constructor]
@@ -38,7 +38,7 @@ mod Verifier {
         starknetid_contract: ContractAddress,
         public_key: felt252
     ) {
-        self.admin.write(admin);
+        self.Proxy_admin.write(admin);
         self._starknetid_contract.write(starknetid_contract);
         self._public_key.write(public_key);
     }
@@ -81,7 +81,7 @@ mod Verifier {
         }
 
         fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
-            assert(get_caller_address() == self.admin.read(), 'you are not admin');
+            assert(get_caller_address() == self.Proxy_admin.read(), 'you are not admin');
             assert(!new_class_hash.is_zero(), 'Class hash cannot be zero');
             starknet::replace_class_syscall(new_class_hash).unwrap();
         }


### PR DESCRIPTION
This pull request is a fix to not lose ownership of the contract after upgrading using the same storage var name as in Cairo 0: 
https://github.com/OpenZeppelin/cairo-contracts/blob/4dd04250c55ae8a5bbcb72663c989bb204e8d998/src/openzeppelin/upgrades/library.cairo#L32C6-L32C17

classhash: `0x368e177b7e5dd4196cdee83ed6dbc35f9538ee9a799f1d8427503e0c6ebd2ab`